### PR TITLE
Homepage Specializations only show if vendors attached

### DIFF
--- a/api/views/specialization_view.py
+++ b/api/views/specialization_view.py
@@ -14,5 +14,5 @@ class SpecializationView(generics.ListAPIView):
     def get_queryset(self):
         home_page = self.request.query_params.get('homePage')
         if home_page:
-            return Specialization.objects.filter(on_homepage=True)
+            return Specialization.objects.filter(on_homepage=True, userspecialization__user__user_type__name='Vendor').distinct()
         return super().get_queryset()


### PR DESCRIPTION
This PR addresses this Ticket: #35 

specializations will show up on homepage only if there are vendors associated with that specialty. I updated the Postman documentation to reflect the change.

to test:
`git fetch vendor-specializations`

endpoint: 
`http://localhost:8000/api/vendorServices?homePage=True
`