### PR TITLE
added pagination to user list

### DIFF
--- a/adminportal/views/user_list.py
+++ b/adminportal/views/user_list.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from django.contrib.auth.decorators import user_passes_test
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from api.models import User
 from adminportal.serializers.serializers import UserListSerializer
 
@@ -8,8 +9,19 @@ def user_is_superuser(user):
 
 @user_passes_test(user_is_superuser, login_url="access_denied")
 def user_list(request):
-    users = User.objects.exclude(user__is_superuser=True)
-    user_data = UserListSerializer(users, many=True).data
+    # order by descending id so newest additions will show first
+    user_list = User.objects.exclude(user__is_superuser=True).order_by('-id')
+    
+    paginator = Paginator(user_list, 10)
+    page = request.GET.get('page')
+
+    try:
+        users = paginator.page(page)
+    except PageNotAnInteger:
+        users = paginator.page(1)
+    except EmptyPage:
+        users = paginator.page(paginator.num_pages)
+    
     return render(request, "adminportal/user_list.html", {
-        "users": user_data
+        "users": users
     })

--- a/templates/adminportal/user_list.html
+++ b/templates/adminportal/user_list.html
@@ -39,7 +39,23 @@
                 </div>
                 {% endfor %}
             </tbody>
-        </table>
+          </table>
+          <div class="pagination">
+            <span class="step-links">
+                {% if users.has_previous %}
+                    <a href="?page=1">&laquo; first</a>
+                    <a href="?page={{ users.previous_page_number }}">previous</a>
+                {% endif %}
+                <span class="current">
+                    Page {{ users.number }} of {{ users.paginator.num_pages }}.
+                </span>
+        
+                {% if users.has_next %}
+                    <a href="?page={{ users.next_page_number }}">next</a>
+                    <a href="?page={{ users.paginator.num_pages }}">last &raquo;</a>
+                {% endif %}
+            </span>
+        </div>
         <button type="button" class="btn btn-primary" id="toggleButton">Update Approval List</button>
         <button type="submit" class="btn btn-primary">Submit Approval List</button>
     </form>


### PR DESCRIPTION
This PR adds pagination to the user list page on admin portal. It should display 10 users at a time, ordered by most recent to oldest.

To test:
`git fetch user-pagination`
Log in as superuser.