### PR TITLE
modified agent and vendor lists to only return active profiles

### DIFF
--- a/api/views/agent_view.py
+++ b/api/views/agent_view.py
@@ -21,7 +21,7 @@ class AgentView(ViewSet):
 
     def list(self, request):
         """returns list of agents"""
-        agents = User.objects.filter(user_type__name='Realtor')
+        agents = User.objects.filter(user_type__name='Realtor', active=True)
         specialty = request.query_params.get('specialty')
         if specialty is not None:
             agents = agents.filter(user_specialization__specialization__tag_name=specialty)

--- a/api/views/home_page_search.py
+++ b/api/views/home_page_search.py
@@ -20,7 +20,7 @@ class SearchView(ViewSet):
             counties = UserCounty.objects.filter(user__user_type__name=user_type, county__state__name=state)
             response = set([county.county.name for county in counties])
         else:
-            user_list = users.filter(user_county__county__name=county, user_county__county__state__name=state)
+            user_list = users.filter(user_county__county__name=county, user_county__county__state__name=state, active=True)
             serializer = UserSerializer(user_list, many=True)
             response = serializer.data
 

--- a/api/views/vendor_view.py
+++ b/api/views/vendor_view.py
@@ -21,7 +21,7 @@ class VendorView(ViewSet):
 
     def list(self, request):
         """returns list of Vendors"""
-        vendors = User.objects.filter(user_type__name='Vendor')
+        vendors = User.objects.filter(user_type__name='Vendor', active=True)
         specialty = request.query_params.get('specialty')
         if specialty is not None:
             vendors = vendors.filter(user_specialization__specialization__tag_name=specialty)


### PR DESCRIPTION
This PR modifies the API so that only active users are returned in agent and vendor lists.

To test:
`git fetch only-approved-users`

Endpoints:
`get all agents`
`get all vendors`
