### PR TITLE
added CRUD for specializations in admin portal

### DIFF
--- a/adminportal/urls.py
+++ b/adminportal/urls.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.urls import path
 from django.views.generic import TemplateView
-from adminportal.views import user_list, update_approval, edit_blog, create_blog, blog_list, delete_blog, create_shop_item, edit_shop_item, shop_list, delete_shop_item
+from adminportal.views import user_list, update_approval, edit_blog, create_blog, blog_list, delete_blog, create_shop_item, edit_shop_item, shop_list, delete_shop_item, create_specialization, edit_specialization, specialization_list, delete_specialization
 
 app_name = "adminportal"
 
@@ -17,4 +17,8 @@ urlpatterns = [
   path(f"{app_name}/edit_shop_item/<int:pk>", edit_shop_item, name="edit_shop_item"),
   path(f"{app_name}/shop_list", shop_list, name="shop_list"),
   path(f"{app_name}/delete_shop_item/<int:pk>", delete_shop_item, name="delete_shop_item"),
+  path(f"{app_name}/create_specialization", create_specialization, name="create_specialization"),
+  path(f"{app_name}/edit_specialization/<int:pk>", edit_specialization, name="edit_specialization"),
+  path(f"{app_name}/specialization_list", specialization_list, name="specialization_list"),
+  path(f"{app_name}/delete_specialization/<int:pk>", delete_specialization, name="delete_specialization"),
 ]

--- a/adminportal/views/__init__.py
+++ b/adminportal/views/__init__.py
@@ -2,3 +2,4 @@ from .user_list import user_list, user_is_superuser
 from .user_approval import update_approval
 from .blog import edit_blog, create_blog, blog_list, delete_blog
 from .shop_item import create_shop_item, edit_shop_item, shop_list, delete_shop_item
+from .specialization import create_specialization, edit_specialization, specialization_list, delete_specialization

--- a/adminportal/views/specialization.py
+++ b/adminportal/views/specialization.py
@@ -1,0 +1,94 @@
+from django.shortcuts import render, redirect
+from django.contrib.auth.decorators import user_passes_test
+from api.models import Specialization
+from api.serializers import SpecializationSerializer
+from adminportal.views import user_is_superuser
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+
+@user_passes_test(user_is_superuser, login_url="user_login")
+def create_specialization(request):
+    if request.method == 'POST':
+
+        tag_name = request.POST.get("tag_name")
+        description = request.POST.get("description")
+        on_homepage = request.POST.get("on_homepage")
+        
+        if on_homepage is not None:
+          on_homepage = True
+        else:
+          on_homepage = False
+        
+        Specialization.objects.create(
+          tag_name=tag_name,
+          description=description,
+          on_homepage=on_homepage
+        )
+        
+        specializations = Specialization.objects.all()
+        specialization_data = SpecializationSerializer(specializations, many=True).data
+        
+        return redirect('specialization_list')
+    
+    else:
+
+        homepage_count = Specialization.objects.filter(on_homepage=True).count()
+        return render(request, "adminportal/specialization_form.html", {
+          "homepage_limit": homepage_count >= 6
+        })
+
+@user_passes_test(user_is_superuser, login_url="user_login")
+def edit_specialization(request, pk):
+    specialization = Specialization.objects.get(pk=pk)
+    
+    if request.method == 'POST':
+      
+        tag_name = request.POST.get("tag_name")
+        description = request.POST.get("description")
+        on_homepage = request.POST.get("on_homepage")
+        
+        if on_homepage is not None:
+          on_homepage = True
+        else:
+          on_homepage = False
+        
+        specialization.tag_name = tag_name
+        specialization.description = description
+        specialization.on_homepage = on_homepage
+        specialization.save()
+        
+        specializations = Specialization.objects.all()
+        specialization_data = SpecializationSerializer(specializations, many=True)
+        
+        return redirect('specialization_list')
+    
+    specialization_data = SpecializationSerializer(specialization).data
+    homepage_count = Specialization.objects.filter(on_homepage=True).count()
+    
+    return render(request, "adminportal/specialization_form.html", {
+      "specialization": specialization_data,
+      "homepage_limit": homepage_count >= 6
+    })
+
+@user_passes_test(user_is_superuser, login_url="user_login")
+def specialization_list(request):
+    specialization_list = Specialization.objects.all()
+    paginator = Paginator(specialization_list, 10)
+    page = request.GET.get('page')
+
+    try:
+        specializations = paginator.page(page)
+    except PageNotAnInteger:
+        specializations = paginator.page(1)
+    except EmptyPage:
+        specializations = paginator.page(paginator.num_pages)
+    return render(request, "adminportal/specialization_list.html", {
+        "specializations": specializations
+    })
+
+@user_passes_test(user_is_superuser, login_url="user_login")
+def delete_specialization(request, pk):
+    specialization = Specialization.objects.get(pk=pk)
+    specialization.delete()
+    
+    return redirect('specialization_list')
+        

--- a/templates/adminapp/base/header.html
+++ b/templates/adminapp/base/header.html
@@ -17,6 +17,9 @@
         <li class="nav-item">
           <a class="nav-link" href="{% url 'shop_list' %}">Shop</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{% url 'specialization_list' %}">Specializations</a>
+        </li>
       </ul>
       {% endif %}
 

--- a/templates/adminportal/specialization_form.html
+++ b/templates/adminportal/specialization_form.html
@@ -27,7 +27,7 @@
       {% endif %}
       
       <button type="submit" class="btn btn-outline-success">Submit Specialization</button>
-      {% if item.id %}
+      {% if specialization.id %}
       <a href="{% url 'delete_specialization' specialization.id %}">
       <button id="delete" type="button" class="btn btn-outline-danger"><i class="bi bi-trash"></i>Delete Specialization</button>
       </a>

--- a/templates/adminportal/specialization_form.html
+++ b/templates/adminportal/specialization_form.html
@@ -1,0 +1,44 @@
+{% extends "adminapp/base/index.html" %}
+
+{% block content %}
+  <div class="container mt-5">
+    <h2>{% if specialization.id %}Edit Specialization{% else %}Add Specialization{% endif %}</h2>
+    <form method="POST" action="{% if specialization.id %}{% url 'edit_specialization' specialization.id %}{% else %}{% url 'create_specialization' %}{% endif %}" class="mt-4">
+      {% csrf_token %}
+      
+      <div class="mb-3">
+        <label for="name" class="form-label">Tag Name:</label>
+        <input type="text" name="tag_name" id="tag_name" class="form-control" value="{{ specialization.tag_name|default:"" }}" required>
+      </div>
+      
+      <div class="mb-3">
+        <label for="description" class="form-label">Description:</label>
+        <textarea name="description" id="description" class="form-control" rows="5" required>{{ specialization.description|default:"" }}</textarea>
+      </div>
+
+      <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" name="on_homepage" id="flexSwitchCheckCheckedDisabled" {% if specialization.on_homepage %}checked{% endif %} {% if homepage_limit and not specialization.on_homepage %}disabled{% endif %}>
+        <label class="form-check-label" for="flexSwitchCheckCheckedDisabled">Display on Homepage?</label>
+      </div>
+      {% if homepage_limit and not specialization.on_homepage %}
+      <div class="alert alert-danger">
+        Only 6 specializations may be on the homepage at a time! please edit another specialization if you would like this on the homepage.
+      </div>
+      {% endif %}
+      
+      <button type="submit" class="btn btn-outline-success">Submit Specialization</button>
+      {% if item.id %}
+      <a href="{% url 'delete_specialization' specialization.id %}">
+      <button id="delete" type="button" class="btn btn-outline-danger"><i class="bi bi-trash"></i>Delete Specialization</button>
+      </a>
+      {% endif %}
+    </form>
+  </div>
+  <script>
+    document.getElementById("delete").addEventListener("click", function(e) {
+        if (!confirm("Are you sure you want to delete this specialization? This action cannot be undone!")) {
+            e.preventDefault();
+        }
+    });
+  </script>
+{% endblock %}

--- a/templates/adminportal/specialization_list.html
+++ b/templates/adminportal/specialization_list.html
@@ -1,0 +1,48 @@
+{% extends "adminapp/base/index.html" %}
+{% block content %}
+<div class="specialization-list container">
+  <h1 class="center-text">Specializations</h1>
+  <h4 class="center-text">Click specialization to see details</h4>
+  <div class="shopButtons">
+    <a href="{% url 'create_specialization' %}">
+      <button class="btn btn-outline-dark">Add a specialization</button>
+    </a>
+  </div>
+  <table class="table table-striped table-bordered">
+    <thead>
+        <tr>
+            <th class="center-text">Tag Name</th>
+            <th class="center-text">Description</th>
+            <th class="center-text">On Homepage?</th>
+        </tr>
+    </thead>
+    <tbody id="itemTable">
+        {% for specialization in specializations %}
+        <div>
+          <tr>
+            <td class="center-text"><a href="{% url 'edit_specialization' specialization.id %}">{{ specialization.tag_name }}</a></td>
+            <td class="center-text">{{ specialization.description }}</td>
+            <td class="center-text">{% if specialization.on_homepage %}Yes{% else %}No{% endif %}</td>
+          </tr>
+        </div>
+        {% endfor %}
+    </tbody>
+  </table>
+  <div class="pagination">
+    <span class="step-links">
+        {% if specializations.has_previous %}
+            <a href="?page=1">&laquo; first</a>
+            <a href="?page={{ specializations.previous_page_number }}">previous</a>
+        {% endif %}
+        <span class="current">
+            Page {{ specializations.number }} of {{ specializations.paginator.num_pages }}.
+        </span>
+
+        {% if specializations.has_next %}
+            <a href="?page={{ specializations.next_page_number }}">next</a>
+            <a href="?page={{ specializations.paginator.num_pages }}">last &raquo;</a>
+        {% endif %}
+    </span>
+</div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This PR adds CRUD functionality to specializations in the admin view.

to test:
- ```shell
  git fetch origin specialization-crud
  ```
- ```shell
  python manage.py runserver
  ```
- Log in as superuser 

AC:
- There is a Specialization link in the navbar
- A superuser can view all specializations
- A superuser can create a new specialization
- A superuser can edit a current specialization

Notes:
- Only 6 specializations can be set to on_homepage = True at a time. You will see an alert and the radio will be disabled if you can not set it to true from the form.

![Screen Shot 2024-01-12 at 4 02 23 PM](https://github.com/Muka-is-home/api/assets/73616016/fa89f977-e7a9-4b82-bb75-d9ab6091dc59)
