### PR TITLE
added profile picture change to user detail screen

### DIFF
--- a/adminapp/urls.py
+++ b/adminapp/urls.py
@@ -1,7 +1,7 @@
 # https://www.django-rest-framework.org/api-guide/routers/
 from django.urls import path
 from django.views.generic import TemplateView
-from adminapp.views import UserLoginView, user_detail, profile_signup, edit_profile, create_profile, signup, user_licenses, user_logout, edit_licenses
+from adminapp.views import UserLoginView, user_detail, profile_signup, edit_profile, create_profile, signup, user_licenses, user_logout, edit_licenses, update_profile_picture
 app_name = "muka"
 
 urlpatterns = [
@@ -17,5 +17,6 @@ urlpatterns = [
     template_name = "adminapp/thank_you.html"
   ), name="thank_you"),
   path(f"{app_name}/rejected", TemplateView.as_view(template_name="adminapp/rejection.html"), name="rejection"),
-  path(f"{app_name}/edit_licenses/<int:pk>", edit_licenses, name="edit_licenses")
+  path(f"{app_name}/edit_licenses/<int:pk>", edit_licenses, name="edit_licenses"),
+  path(f"{app_name}/update_profile_image/<int:pk>", update_profile_picture, name='update_profile_image')
 ]

--- a/adminapp/views/__init__.py
+++ b/adminapp/views/__init__.py
@@ -1,5 +1,5 @@
 from .login import UserLoginView
-from .user_view import user_detail, edit_profile, create_profile, user_licenses, edit_licenses
+from .user_view import user_detail, edit_profile, create_profile, user_licenses, edit_licenses, update_profile_picture
 from .profile_signup import profile_signup
 from .signup import signup
 from .logout import user_logout

--- a/adminapp/views/user_view.py
+++ b/adminapp/views/user_view.py
@@ -251,4 +251,21 @@ def edit_licenses(request, pk):
         "user_counties": user_county_ids,
         "licenses": user_data["licenses"]
     })
+
+@login_required
+def update_profile_picture(request, pk):
     
+    image = handle_image_upload(request, request.POST.get("slug"))
+    
+    if image:
+        
+        user = User.objects.get(pk=pk)
+        user.image = image
+        user.save()
+        
+        user_data = UserFormSerializer(user).data
+        return render(request, "adminapp/user_detail.html", {
+            "user": user_data
+        })
+
+    return redirect("user_list")

--- a/templates/adminapp/user_detail.html
+++ b/templates/adminapp/user_detail.html
@@ -14,8 +14,39 @@
                       <p class="text-muted font-size-sm">{{ user.company }}</p>
                       {% if request.user.is_superuser %}
                       <a href="mailto:{{ user.email }}">
-                        <button class="btn btn-outline-primary">Message</button>
+                        <button class="btn btn-info">Message</button>
                       </a>
+                      {% endif %}
+                      {% if not request.user.is_superuser %}
+                      <!-- Button trigger modal -->
+                      <button type="button" class="btn btn-info" data-bs-toggle="modal" data-bs-target="#exampleModal">
+                        Change Profile Picture
+                      </button>
+
+                      <!-- Modal -->
+                      <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                        <div class="modal-dialog">
+                          <div class="modal-content">
+                            <div class="modal-header">
+                              <h5 class="modal-title" id="exampleModalLabel">Upload Image</h5>
+                              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <div class="modal-body">
+                              <form method="POST" enctype="multipart/form-data" action="{% url 'update_profile_image' user.id %}" class="mt-4">
+                                {% csrf_token %}
+                                <div class="mb-3">
+                                  <input class="form-control" name="image" type="file" id="formFile">
+                                  <input type="hidden" name="slug" value="{{ user.name }}" type="text">
+                                </div>
+                                <button type="submit" class="btn btn-outline-success">Update Profile Picture</button>
+                              </form>
+                            </div>
+                            <div class="modal-footer">
+                              <button type="button" class="btn btn-danger" data-bs-dismiss="modal">Cancel</button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
                       {% endif %}
                     </div>
                   </div>


### PR DESCRIPTION
This PR adds the ability to change your profile picture directly from the User Detail page via a modal.

To Test:
```shell
git fetch origin update-profile-pic
```
```shell
git checkout update-profile-pic
```
```shell
python manage.py migrate
```
```shell
python manage.py runserver
```
- Log in as a regular user

AC:
- There is a button under the profile pic that says change profile picture
- You can upload  a photo
- After submitting the item, you are taken back to the user detail page with an updated photo.